### PR TITLE
Fix encoding of identity parameter in URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@
   Verifier.prototype = function() {
     var lookupIdentity = function(identity) {
       var deferred = Q.defer();
-      var endPointUrl = this.host + '/identities/' + identity;
+      var endPointUrl = this.host + '/identities/' + encodeURIComponent(identity);
 
       console.log("Looking up identity from URL: " + endPointUrl);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@
 
     var registerEndpoint = function(endpoint) {
       var deferred = Q.defer();
-      var endPointUrl = this.host + '/identities/' + this.identity + '/endpoints/' + endpoint;
+      var endPointUrl = this.host + '/identities/' + encodeURIComponent(this.identity) + '/endpoints/' + encodeURIComponent(endpoint);
 
       console.log("Trying to register endpoint with URL: " + endPointUrl);
 


### PR DESCRIPTION
So no spaces or weird symbols are parsed incorrect.
